### PR TITLE
Allow for the removal of the require

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,11 @@ then on the command line:
 
      browserify -t deassertify example.js > bundle.js
 
+You can also pass in the argument `nobundle` to prevent the assert package
+from being added to your bundle.
+
+     browserify -t [deassertify --nobundle] example.js > bundle.js
+
 or with the api:
 
 ```javascript

--- a/deassertify.js
+++ b/deassertify.js
@@ -4,7 +4,7 @@ var through = require("through2")
 module.exports = function (file, opts) {
   if (/\.json$/.test(file)) return through()
 
-  opts = opts || {}
+  opts = opts || {nobundle: false}
 
   var data = ""
 
@@ -25,6 +25,10 @@ module.exports = function (file, opts) {
 
 function parse (data, opts) {
     return falafel(data, function (node) {
+      if (opts.nobundle && node.type == "VariableDeclaration" && node.source().match(/require\(.{1}assert/)) {
+        return node.update(node.source().split(/\n|\r/).map(function(f){ return "//-- " + f;}).join("\n"));
+      }
+
       if (node.type != "DebuggerStatement" && (node.type != "CallExpression" || !isAssert(node.callee))) {
              return;
       }

--- a/test/expected/nobundle-script1.js
+++ b/test/expected/nobundle-script1.js
@@ -1,0 +1,7 @@
+//-- var assert = require("assert");
+
+function foo(a) {
+
+  //-- assert(a>0,"check");
+  return a *2;
+}

--- a/test/expected/nobundle-script2.js
+++ b/test/expected/nobundle-script2.js
@@ -1,0 +1,9 @@
+//-- var assert = require("assert");
+
+function foo(a) {
+
+  //-- assert( this < is &&
+//--           a < multi && 
+//--           line && assert);
+  return a *2;
+}

--- a/test/test.js
+++ b/test/test.js
@@ -29,3 +29,29 @@ describe("testing desassertify",function() {
      test_file(file,done);
    });
 });
+
+describe("testing desassertify no require",function() {
+  var files = fs.readdirSync(path.join(__dirname, "fixtures"));
+  function test_file(file,done) {
+    var filePath = path.join(__dirname, "fixtures", file);
+    var opts = {nobundle: true};
+    fs.createReadStream(filePath)
+      .pipe(deassertify(filePath, opts))
+      .pipe(concat({encoding: 'string'},
+          function (stripped) {
+               fs.readFile(path.join(__dirname, "expected", "nobundle-"+file), "utf8", function (err, expectation) {
+                      should(err).eql(null,"No error reading expectation file");
+                      stripped.should.eql(expectation, "Transformed file contents equal expected file contents");
+                      done();
+               });
+          }));
+  }
+  it("should comment out asserts statement in code",function(done){
+    var file = "script1.js";
+    test_file(file,done);
+  });
+  it("should comment out mutli line asserts statement in code",function(done){
+     var file = "script2.js";
+     test_file(file,done);
+   });
+});


### PR DESCRIPTION
Should be able to prevent browserify from bundling assert and saving some kb in the process for your bundle.

I wasn't sure where to place the `if` -- didn't want to make the current `if` clause longer. If the option isn't set, it'll fail out on the first clause meaning it doesn't have to parse the rest.

Happy to refactor this to something more to your liking if needed.
